### PR TITLE
Updated to express 3.4.0

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ app.configure(function(){
   app.use(express.csrf());
 
   app.use(function (req, res, next) {
-    res.locals.csrftoken = req.session._csrf;
+    res.locals.csrftoken = req.csrfToken();
     next();
   });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node app"
   },
   "dependencies": {
-    "express": "~3.1.0",
+    "express": "~3.4.0",
     "jade": "*",
     "helmet": "0.0.7"
   }


### PR DESCRIPTION
Just if you want to update to express 3.4, req.session._csrf becomes req.csrfToken() 
