### PR TITLE
bodyParser() was removed from express.

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,8 @@ app.use(express.logger('dev'));
 //app.use(helmet.iexss());
 //app.use(helmet.contentTypeOptions());
 //app.use(helmet.cacheControl());
-app.use(express.bodyParser());
+app.use(express.urlencoded());
+app.use(express.json());
 app.use(express.methodOverride());
 app.use(express.cookieParser('optional secret string'));
 app.use(express.session({


### PR DESCRIPTION
I think these lines replace **bodyParser();**

```
app.use(express.urlencoded());
app.use(express.json());
```

This should eliminate the warning.

>  connect.multipart() will be removed in connect 3.0 visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives connect.limit() will be removed in connect 3.0

Link to express issue.

```
https://github.com/visionmedia/express/issues/1793
```
