### PR TITLE
Disable X-Powered-By header and fix express.bodyParser() warning.

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,10 +10,7 @@ var app = express();
 app.set('port', process.env.PORT || 3000);
 app.set('views', __dirname + '/views');
 app.set('view engine', 'jade');
-
-// Remove the X-Powered-By header without using middleware.
-app.disable('x-powered-by')
-
+app.disable('x-powered-by');
 app.use(express.favicon());
 app.use(express.logger('dev'));
 //app.use(helmet.xframe());


### PR DESCRIPTION
- Disables the X-Powered-By header without middleware.
- Replaces express.bodyParser() with express.json() and express.urlencoded(). This removes a warning from connect.

>  connect.multipart() will be removed in connect 3.0
>  visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
>  connect.limit() will be removed in connect 3.0
